### PR TITLE
changed to py3.7 & fixed urlib method

### DIFF
--- a/toast-base.yaml
+++ b/toast-base.yaml
@@ -91,7 +91,7 @@ Resources:
               sns_message = ast.literal_eval(event['Records'][0]['Sns']['Message'])
               source_bucket = str(sns_message['Records'][0]['s3']['bucket']['name'])
               dest_bucket = os.environ.get('BUCKET_NAME')
-              key = str(urllib.unquote_plus(sns_message['Records'][0]['s3']['object']['key']).decode('utf8'))
+              key = str(urllib.parse.quote_plus(sns_message['Records'][0]['s3']['object']['key']))
               if not _get_key_exists(dest_bucket, key):
                   copy_source = {'Bucket':source_bucket, 'Key':key}
                   s3.copy_object(Bucket=dest_bucket, Key=key, CopySource=copy_source)
@@ -103,7 +103,7 @@ Resources:
       FunctionName: !Join [ "-", [ !Ref UniqueIdentifier, "ToastNotifier", !Ref "AWS::Region" ] ]
       Handler: "index.lambda_handler"
       Role: !GetAtt ToastReplicatorRole.Arn
-      Runtime: python2.7
+      Runtime: python3.7
       MemorySize: 256
       Timeout: 60 # 60 second timeout
   ToastReplicatorRole: # allow lambda to assume role


### PR DESCRIPTION
i've changed the runtime to 3.7 as AWS doesn't support new lambdas running 2.7 anymore.
updated urllib as the new module doesn't use the previous method and already decodes in UTF-8 format so you don't have to specify it